### PR TITLE
Fix leak of mech OID in gssi_inquire_context()

### DIFF
--- a/src/mechglue/gpp_import_and_canon_name.c
+++ b/src/mechglue/gpp_import_and_canon_name.c
@@ -257,6 +257,8 @@ OM_uint32 gssi_release_name(OM_uint32 *minor_status,
         return GSS_S_BAD_NAME;
     }
 
+    (void)gss_release_oid(&rmin, &name->mech_type);
+
     rmaj = gpm_release_name(&rmin, &name->remote);
 
     if (name->local) {


### PR DESCRIPTION
The name it creates holds a copy of the OID, which we need to release.

Signed-off-by: Robbie Harwood <rharwood@redhat.com>