### PR TITLE
We leak

### DIFF
--- a/src/client/gpm_common.c
+++ b/src/client/gpm_common.c
@@ -799,4 +799,3 @@ void gpm_free_xdrs(int proc, union gp_rpc_arg *arg, union gp_rpc_res *res)
     xdr_free(gpm_xdr_set[proc].arg_fn, (char *)arg);
     xdr_free(gpm_xdr_set[proc].res_fn, (char *)res);
 }
-

--- a/src/client/gpm_indicate_mechs.c
+++ b/src/client/gpm_indicate_mechs.c
@@ -95,20 +95,6 @@ static uint32_t gpm_copy_gss_buffer(uint32_t *minor_status,
     return GSS_S_COMPLETE;
 }
 
-static bool gpm_equal_oids(gss_const_OID a, gss_const_OID b)
-{
-    int ret;
-
-    if (a->length == b->length) {
-        ret = memcmp(a->elements, b->elements, a->length);
-        if (ret == 0) {
-            return true;
-        }
-    }
-
-    return false;
-}
-
 static void gpmint_indicate_mechs(void)
 {
     union gp_rpc_arg uarg;
@@ -313,7 +299,7 @@ int gpm_mech_to_static(gss_OID mech_type, gss_OID *mech_static)
 
     *mech_static = GSS_C_NO_OID;
     for (size_t i = 0; i < global_mechs.mech_set->count; i++) {
-        if (gpm_equal_oids(&global_mechs.mech_set->elements[i], mech_type)) {
+        if (gss_oid_equal(&global_mechs.mech_set->elements[i], mech_type)) {
             *mech_static = &global_mechs.mech_set->elements[i];
             return 0;
         }
@@ -383,7 +369,7 @@ OM_uint32 gpm_inquire_names_for_mech(OM_uint32 *minor_status,
     }
 
     for (unsigned i = 0; i < global_mechs.info_len; i++) {
-        if (!gpm_equal_oids(global_mechs.info[i].mech, mech_type)) {
+        if (!gss_oid_equal(global_mechs.info[i].mech, mech_type)) {
             continue;
         }
         ret_maj = gpm_copy_gss_OID_set(&ret_min,
@@ -481,7 +467,7 @@ OM_uint32 gpm_inquire_attrs_for_mech(OM_uint32 *minor_status,
     }
 
     for (unsigned i = 0; i < global_mechs.info_len; i++) {
-        if (!gpm_equal_oids(global_mechs.info[i].mech, mech)) {
+        if (!gss_oid_equal(global_mechs.info[i].mech, mech)) {
             continue;
         }
 
@@ -540,7 +526,7 @@ OM_uint32 gpm_inquire_saslname_for_mech(OM_uint32 *minor_status,
     }
 
     for (unsigned i = 0; i < global_mechs.info_len; i++) {
-        if (!gpm_equal_oids(global_mechs.info[i].mech, desired_mech)) {
+        if (!gss_oid_equal(global_mechs.info[i].mech, desired_mech)) {
             continue;
         }
         ret_maj = gpm_copy_gss_buffer(&ret_min,
@@ -598,7 +584,7 @@ OM_uint32 gpm_display_mech_attr(OM_uint32 *minor_status,
     }
 
     for (unsigned i = 0; i < global_mechs.desc_len; i++) {
-        if (!gpm_equal_oids(global_mechs.desc[i].attr, mech_attr)) {
+        if (!gss_oid_equal(global_mechs.desc[i].attr, mech_attr)) {
             continue;
         }
         ret_maj = gpm_copy_gss_buffer(&ret_min,

--- a/src/client/gpm_indicate_mechs.c
+++ b/src/client/gpm_indicate_mechs.c
@@ -390,7 +390,7 @@ OM_uint32 gpm_inquire_mechs_for_name(OM_uint32 *minor_status,
     uint32_t ret_min;
     uint32_t ret_maj;
     uint32_t discard;
-    gss_OID name_type = GSS_C_NO_OID;
+    gss_OID_desc name_type;
     int present;
 
     if (!minor_status) {
@@ -407,19 +407,14 @@ OM_uint32 gpm_inquire_mechs_for_name(OM_uint32 *minor_status,
         return GSS_S_FAILURE;
     }
 
-    ret_min = gp_conv_gssx_to_oid_alloc(&input_name->name_type, &name_type);
-    if (ret_min) {
-        ret_maj = GSS_S_FAILURE;
-        goto done;
-    }
-
     ret_maj = gss_create_empty_oid_set(&ret_min, mech_types);
     if (ret_maj) {
         goto done;
     }
 
+    gp_conv_gssx_to_oid(&input_name->name_type, &name_type);
     for (unsigned i = 0; i < global_mechs.info_len; i++) {
-        ret_maj = gss_test_oid_set_member(&ret_min, name_type,
+        ret_maj = gss_test_oid_set_member(&ret_min, &name_type,
                                           global_mechs.info[i].name_types,
                                           &present);
         if (ret_maj) {
@@ -437,7 +432,6 @@ OM_uint32 gpm_inquire_mechs_for_name(OM_uint32 *minor_status,
     }
 
 done:
-    gss_release_oid(&discard, &name_type);
     if (ret_maj) {
         gss_release_oid_set(&discard, mech_types);
         *minor_status = ret_min;

--- a/src/client/gpm_inquire_context.c
+++ b/src/client/gpm_inquire_context.c
@@ -51,7 +51,9 @@ OM_uint32 gpm_inquire_context(OM_uint32 *minor_status,
     }
 
     if (mech_type) {
-        ret = gp_conv_gssx_to_oid_alloc(&context_handle->mech, mech_type);
+        gss_OID_desc mech;
+        gp_conv_gssx_to_oid(&context_handle->mech, &mech);
+        ret = gpm_mech_to_static(&mech, mech_type);
         if (ret) {
             if (src_name) {
                 (void)gpm_release_name(&tmp_min, src_name);

--- a/src/client/gpm_release_handle.c
+++ b/src/client/gpm_release_handle.c
@@ -106,5 +106,7 @@ rel_done:
     gpm_free_xdrs(GSSX_RELEASE_HANDLE, &uarg, &ures);
 done:
     xdr_free((xdrproc_t)xdr_gssx_ctx, (char *)r);
+    free(r);
+    *context_handle = NULL;
     return ret;
 }

--- a/src/client/gssapi_gpm.h
+++ b/src/client/gssapi_gpm.h
@@ -27,6 +27,9 @@ void gpm_display_status_init_once(void);
 void gpm_save_status(gssx_status *status);
 void gpm_save_internal_status(uint32_t err, char *err_str);
 
+int gpm_mech_to_static(gss_OID mech_type, gss_OID *mech_static);
+bool gpm_mech_is_static(gss_OID mech_type);
+
 OM_uint32 gpm_display_status(OM_uint32 *minor_status,
                              OM_uint32 status_value,
                              int status_type,

--- a/src/client/gssapi_gpm.h
+++ b/src/client/gssapi_gpm.h
@@ -10,6 +10,7 @@
 #include <string.h>
 #include <gssapi/gssapi.h>
 #include <gssapi/gssapi_ext.h>
+#include <gssapi/gssapi_krb5.h>
 #include "rpcgen/gp_rpc.h"
 #include "rpcgen/gss_proxy.h"
 #include "src/gp_common.h"

--- a/src/gp_creds.c
+++ b/src/gp_creds.c
@@ -775,6 +775,7 @@ static uint32_t get_impersonator_fallback(uint32_t *min, gss_cred_id_t cred,
     uint32_t ret_maj = 0;
     uint32_t ret_min = 0;
     char *memcache = NULL;
+    char **ptr = &memcache;
     krb5_context context = NULL;
     krb5_ccache ccache = NULL;
     krb5_data config;
@@ -791,7 +792,7 @@ static uint32_t get_impersonator_fallback(uint32_t *min, gss_cred_id_t cred,
     gss_key_value_element_desc ccelement = { "ccache", NULL };
     gss_key_value_set_desc cred_store = { 1, &ccelement };
 
-    err = asprintf(&memcache, "MEMORY:cred_allowed_%p", &memcache);
+    err = asprintf(&memcache, "MEMORY:cred_allowed_%p", ptr);
     if (err == -1) {
         memcache = NULL;
         ret_min = ENOMEM;
@@ -991,6 +992,7 @@ uint32_t gp_count_tickets(uint32_t *min, gss_cred_id_t cred, uint32_t *ccsum)
     uint32_t ret_maj = 0;
     uint32_t ret_min = 0;
     char *memcache = NULL;
+    char **ptr = &memcache;
     krb5_context context = NULL;
     krb5_ccache ccache = NULL;
     krb5_cc_cursor cursor = NULL;
@@ -1008,7 +1010,7 @@ uint32_t gp_count_tickets(uint32_t *min, gss_cred_id_t cred, uint32_t *ccsum)
     gss_key_value_element_desc ccelement = { "ccache", NULL };
     gss_key_value_set_desc cred_store = { 1, &ccelement };
 
-    err = asprintf(&memcache, "MEMORY:cred_allowed_%p", &memcache);
+    err = asprintf(&memcache, "MEMORY:cred_allowed_%p", ptr);
     if (err == -1) {
         memcache = NULL;
         ret_min = ENOMEM;

--- a/src/gp_export.c
+++ b/src/gp_export.c
@@ -308,10 +308,9 @@ static int gp_encrypt_buffer(krb5_context context, krb5_keyblock *key,
     ret = gp_conv_octet_string(enc_handle.ciphertext.length,
                                enc_handle.ciphertext.data,
                                out);
-    if (ret) {
-        free(enc_handle.ciphertext.data);
-        goto done;
-    }
+    /* the conversion function copies the data, so free our copy
+     * unconditionally, or we leak */
+    free(enc_handle.ciphertext.data);
 
 done:
     free(padded);

--- a/src/gssproxy.c
+++ b/src/gssproxy.c
@@ -150,6 +150,11 @@ static void hup_handler(verto_ctx *vctx, verto_ev *ev UNUSED)
     return;
 }
 
+static void init_event(verto_ctx *vctx UNUSED, verto_ev *ev UNUSED)
+{
+    GPDEBUG("Initialization complete.\n");
+}
+
 int main(int argc, const char *argv[])
 {
     int opt;
@@ -287,6 +292,17 @@ int main(int argc, const char *argv[])
 
     ret = gp_workers_init(gpctx);
     if (ret) {
+        ret = EXIT_FAILURE;
+        goto cleanup;
+    }
+
+    /* Schedule an event to run as soon as the event loop is started
+     * This is useful in debug to know that all initialization is done.
+     * Might be used in future to schdule startup one offs that do not
+     * need to be done synchronously */
+    ev = verto_add_timeout(vctx, VERTO_EV_FLAG_NONE, init_event, 1);
+    if (!ev) {
+        fprintf(stderr, "Failed to register init_event with verto!\n");
         ret = EXIT_FAILURE;
         goto cleanup;
     }

--- a/src/mechglue/gpp_creds.c
+++ b/src/mechglue/gpp_creds.c
@@ -895,7 +895,7 @@ done:
     if (maj == GSS_S_COMPLETE) {
         *cred_handle = (gss_cred_id_t)cred;
     } else {
-        free(cred);
+        (void)gpp_cred_handle_free(&min, cred);
     }
     (void)gss_release_buffer(&min, &wrap_token);
     return maj;

--- a/src/mechglue/gpp_init_sec_context.c
+++ b/src/mechglue/gpp_init_sec_context.c
@@ -215,7 +215,7 @@ done:
     *context_handle = (gss_ctx_id_t)ctx_handle;
 
     if (claimant_cred_handle == GSS_C_NO_CREDENTIAL) {
-        free(cred_handle);
+        (void)gpp_cred_handle_free(&min, cred_handle);
     }
     return maj;
 }

--- a/src/mechglue/gss_plugin.c
+++ b/src/mechglue/gss_plugin.c
@@ -65,6 +65,8 @@ enum gpp_behavior gpp_get_behavior(void)
     return behavior;
 }
 
+static void gpp_init_special_available_mechs(const gss_OID_set mechs);
+
 /* 2.16.840.1.113730.3.8.15.1 */
 const gss_OID_desc gssproxy_mech_interposer = {
     .length = 11,
@@ -76,7 +78,6 @@ gss_OID_set gss_mech_interposer(gss_OID mech_type)
     gss_OID_set interposed_mechs;
     OM_uint32 maj, min;
     char *envval;
-    gss_OID_set special_mechs;
 
     /* avoid looping in the gssproxy daemon by avoiding to interpose
      * any mechanism */
@@ -119,8 +120,7 @@ gss_OID_set gss_mech_interposer(gss_OID mech_type)
     }
 
     /* while there also initiaize special_mechs */
-    special_mechs = gpp_special_available_mechs(interposed_mechs);
-    (void)gss_release_oid_set(&min, &special_mechs);
+    gpp_init_special_available_mechs(interposed_mechs);
 
 done:
     if (maj != 0) {
@@ -307,13 +307,13 @@ gss_OID_set gpp_special_available_mechs(const gss_OID_set mechs)
     gss_OID n;
     uint32_t maj, min;
 
-    item = gpp_get_special_oids();
-
     maj = gss_create_empty_oid_set(&min, &amechs);
     if (maj) {
         return GSS_C_NO_OID_SET;
     }
     for (size_t i = 0; i < mechs->count; i++) {
+        item = gpp_get_special_oids();
+
         while (item) {
             if (gpp_is_special_oid(&mechs->elements[i])) {
                 maj = gss_add_oid_set_member(&min,
@@ -352,6 +352,27 @@ done:
         (void)gss_release_oid_set(&min, &amechs);
     }
     return amechs;
+}
+
+static void gpp_init_special_available_mechs(const gss_OID_set mechs)
+{
+    struct gpp_special_oid_list *item;
+
+    for (size_t i = 0; i < mechs->count; i++) {
+        item = gpp_get_special_oids();
+
+        while (item) {
+            if (gpp_is_special_oid(&mechs->elements[i]) ||
+                gpp_special_equal(&item->special_oid, &mechs->elements[i])) {
+                break;
+            }
+            item = gpp_next_special_oids(item);
+        }
+        if (item == NULL) {
+            /* not found, add to static list */
+            (void)gpp_new_special_mech(&mechs->elements[i]);
+        }
+    }
 }
 
 OM_uint32 gssi_internal_release_oid(OM_uint32 *minor_status, gss_OID *oid)

--- a/src/mechglue/gss_plugin.c
+++ b/src/mechglue/gss_plugin.c
@@ -376,6 +376,11 @@ OM_uint32 gssi_internal_release_oid(OM_uint32 *minor_status, gss_OID *oid)
         item = gpp_next_special_oids(item);
     }
 
+    if (gpm_mech_is_static(*oid)) {
+        *oid = GSS_C_NO_OID;
+        return GSS_S_COMPLETE;
+    }
+
     /* none matched, it's not ours */
     return GSS_S_CONTINUE_NEEDED;
 }

--- a/tests/runtests.py
+++ b/tests/runtests.py
@@ -32,7 +32,7 @@ def parse_args():
                               "--args")
     parser.add_argument('--debug-num', default=-1, type=int,
                         help="Specify the testcase number to debug")
-    parser.add_argument('--timeout', default=15, type=int,
+    parser.add_argument('--timeout', default=30, type=int,
                         help="Specify test case timeout limit")
     parser.add_argument('--valgrind-cmd', default="valgrind " +
                         "--track-origins=yes",
@@ -83,15 +83,10 @@ def runtests_main(testfiles):
         if 'TERM' in os.environ:
             gssapienv['TERM'] = os.environ['TERM']
 
-        gssproxylog = os.path.join(testdir, 'gssproxy.log')
-
-        logfile = open(gssproxylog, "a")
-
         gssproxyenv = keysenv
         gssproxyenv['KRB5_TRACE'] = os.path.join(testdir, 'gssproxy.trace')
 
-        gproc, gpsocket = setup_gssproxy(testdir, logfile, gssproxyenv)
-        time.sleep(5) #Give time to gssproxy to fully start up
+        gproc, gpsocket = setup_gssproxy(testdir, gssproxyenv)
         processes['GSS-Proxy(%d)' % gproc.pid] = gproc
         gssapienv['GSSPROXY_SOCKET'] = gpsocket
 

--- a/tests/t_impersonate.c
+++ b/tests/t_impersonate.c
@@ -12,9 +12,9 @@ int main(int argc, const char *argv[])
     gss_ctx_id_t accept_ctx = GSS_C_NO_CONTEXT;
     gss_buffer_desc in_token = GSS_C_EMPTY_BUFFER;
     gss_buffer_desc out_token = GSS_C_EMPTY_BUFFER;
-    gss_name_t user_name;
-    gss_name_t proxy_name;
-    gss_name_t target_name;
+    gss_name_t user_name = GSS_C_NO_NAME;
+    gss_name_t proxy_name = GSS_C_NO_NAME;
+    gss_name_t target_name = GSS_C_NO_NAME;
     gss_OID_set_desc oid_set = { 1, discard_const(gss_mech_krb5) };
     uint32_t ret_maj;
     uint32_t ret_min;
@@ -207,9 +207,14 @@ int main(int argc, const char *argv[])
     ret = 0;
 
 done:
+    gss_release_name(&ret_min, &user_name);
+    gss_release_name(&ret_min, &proxy_name);
+    gss_release_name(&ret_min, &target_name);
     gss_release_buffer(&ret_min, &in_token);
     gss_release_buffer(&ret_min, &out_token);
     gss_release_cred(&ret_min, &impersonator_cred_handle);
     gss_release_cred(&ret_min, &cred_handle);
+    gss_delete_sec_context(&ret_min, &accept_ctx, GSS_C_NO_BUFFER);
+    gss_delete_sec_context(&ret_min, &init_ctx, GSS_C_NO_BUFFER);
     return ret;
 }

--- a/tests/t_impersonate.py
+++ b/tests/t_impersonate.py
@@ -56,8 +56,7 @@ def run(testdir, env, conf):
     keysenv = conf["keysenv"].copy()
     keysenv['KRB5_KTNAME'] = os.path.join(testdir, PROXY_KTNAME)
     update_gssproxy_conf(testdir, keysenv, IMPERSONATE_CONF_TEMPLATE)
-    os.kill(conf["gpid"], signal.SIGHUP)
-    time.sleep(1) #Let gssproxy reload everything
+    gssproxy_reload(testdir, conf['gpid'])
 
     rets = []
 
@@ -119,8 +118,7 @@ def run(testdir, env, conf):
 
     # Reset back gssproxy conf
     update_gssproxy_conf(testdir, keysenv, GSSPROXY_CONF_TEMPLATE)
-    os.kill(conf["gpid"], signal.SIGHUP)
-    time.sleep(1) #Let gssproxy reload everything
+    gssproxy_reload(testdir, conf['gpid'])
 
     e = [r for r in rets if r != 0]
     if len(e) > 0:

--- a/tests/t_init.c
+++ b/tests/t_init.c
@@ -82,6 +82,8 @@ int main(int argc, const char *argv[])
         goto done;
     }
 
+    gss_release_buffer(&ret_min, &out_token);
+
     ret = t_recv_buffer(STDIN_FD, buffer, &buflen);
     if (ret != 0) {
         DEBUG("Failed to read token from STDIN\n");

--- a/tests/t_multi_key.py
+++ b/tests/t_multi_key.py
@@ -33,8 +33,7 @@ def run(testdir, env, conf):
     p1env['client_name'] = MULTI_UPN
     p1env['KRB5_KTNAME'] = os.path.join(testdir, MULTI_KTNAME)
     update_gssproxy_conf(testdir, p1env, GSSPROXY_MULTI_TEMPLATE)
-    os.kill(conf["gpid"], signal.SIGHUP)
-    time.sleep(1) #Let gssproxy reload everything
+    gssproxy_reload(testdir, conf['gpid'])
     r1 = run_basic_test(testdir, env, conf)
 
     print("Testing multiple keys Keytab with second principal",
@@ -48,8 +47,7 @@ def run(testdir, env, conf):
     p2env['client_name'] = MULTI_SVC
     p2env['KRB5_KTNAME'] = os.path.join(testdir, MULTI_KTNAME)
     update_gssproxy_conf(testdir, p2env, GSSPROXY_MULTI_TEMPLATE)
-    os.kill(conf["gpid"], signal.SIGHUP)
-    time.sleep(1) #Let gssproxy reload everything
+    gssproxy_reload(testdir, conf['gpid'])
     r2 = run_basic_test(testdir, env, conf)
 
     if r1 != 0:

--- a/tests/t_program.py
+++ b/tests/t_program.py
@@ -30,8 +30,7 @@ def run(testdir, env, conf):
     sys.stderr.write("  ")
     conf["prefix"] = prefix + "_1"
     update_gssproxy_conf(testdir, conf["keysenv"], GSSPROXY_PROGRAM)
-    os.kill(conf["gpid"], signal.SIGHUP)
-    time.sleep(1)
+    gssproxy_reload(testdir, conf['gpid'])
     retval |= run_acquire_test(testdir, env, conf)
 
     print("Testing negative program name matching...", file=sys.stderr)
@@ -39,14 +38,12 @@ def run(testdir, env, conf):
     conf["prefix"] = prefix + "_2"
     bad_progdir = GSSPROXY_PROGRAM.replace("${PROGDIR}", "//bad/path")
     update_gssproxy_conf(testdir, conf["keysenv"], bad_progdir)
-    os.kill(conf["gpid"], signal.SIGHUP)
-    time.sleep(1)
+    gssproxy_reload(testdir, conf['gpid'])
     retval |= run_acquire_test(testdir, env, conf, expected_failure=True)
 
     # be a good citizen and clean up after ourselves
     update_gssproxy_conf(testdir, conf["keysenv"], GSSPROXY_CONF_TEMPLATE)
-    os.kill(conf["gpid"], signal.SIGHUP)
-    time.sleep(1)
+    gssproxy_reload(testdir, conf['gpid'])
 
     print_return(retval, -1, "Program", False)
     return retval

--- a/tests/t_reloading.py
+++ b/tests/t_reloading.py
@@ -14,8 +14,7 @@ def run(testdir, env, basicconf):
     print("Testing basic SIGHUP with no change", file=sys.stderr)
     sys.stderr.write("  ")
     basicconf['prefix'] += prefix + "_1"
-    os.kill(basicconf["gpid"], signal.SIGHUP)
-    time.sleep(1) #Let gssproxy reload everything
+    gssproxy_reload(testdir, basicconf['gpid'])
     r = run_basic_test(testdir, env, basicconf)
     rets.append(r)
 
@@ -23,8 +22,7 @@ def run(testdir, env, basicconf):
     sys.stderr.write("  ")
     basicconf['prefix'] = prefix + "_2"
     update_gssproxy_conf(testdir, keysenv, GSSPROXY_CONF_MINIMAL_TEMPLATE)
-    os.kill(basicconf["gpid"], signal.SIGHUP)
-    time.sleep(1) #Let gssproxy reload everything
+    gssproxy_reload(testdir, basicconf['gpid'])
     r = run_basic_test(testdir, env, basicconf, True)
     rets.append(r)
 
@@ -32,8 +30,7 @@ def run(testdir, env, basicconf):
     sys.stderr.write("  ")
     basicconf['prefix'] = prefix + "_3"
     update_gssproxy_conf(testdir, keysenv, GSSPROXY_CONF_TEMPLATE)
-    os.kill(basicconf["gpid"], signal.SIGHUP)
-    time.sleep(1) #Let gssproxy reload everything
+    gssproxy_reload(testdir, basicconf['gpid'])
     r = run_basic_test(testdir, env, basicconf)
     rets.append(r)
 
@@ -42,16 +39,14 @@ def run(testdir, env, basicconf):
     basicconf['prefix'] = prefix + "_4"
     update_gssproxy_conf(testdir, keysenv, GSSPROXY_CONF_SOCKET_TEMPLATE)
     env['GSSPROXY_SOCKET'] += "2"
-    os.kill(basicconf["gpid"], signal.SIGHUP)
-    time.sleep(1) #Let gssproxy reload everything
+    gssproxy_reload(testdir, basicconf['gpid'])
     r = run_basic_test(testdir, env, basicconf)
     rets.append(r)
 
     # restore old configuration
     env['GSSPROXY_SOCKET'] = env['GSSPROXY_SOCKET'][:-1]
     update_gssproxy_conf(testdir, keysenv, GSSPROXY_CONF_TEMPLATE)
-    os.kill(basicconf["gpid"], signal.SIGHUP)
-    time.sleep(1) #Let gssproxy reload everything
+    gssproxy_reload(testdir, basicconf['gpid'])
 
     e = [r for r in rets if r != 0]
     if len(e) > 0:

--- a/tests/t_setcredopt.c
+++ b/tests/t_setcredopt.c
@@ -12,8 +12,8 @@ int main(int argc, const char *argv[])
     gss_ctx_id_t accept_ctx = GSS_C_NO_CONTEXT;
     gss_buffer_desc in_token = GSS_C_EMPTY_BUFFER;
     gss_buffer_desc out_token = GSS_C_EMPTY_BUFFER;
-    gss_name_t user_name;
-    gss_name_t target_name;
+    gss_name_t user_name = GSS_C_NO_NAME;
+    gss_name_t target_name = GSS_C_NO_NAME;
     gss_OID_set_desc oid_set = { 1, discard_const(gss_mech_krb5) };
     uint32_t ret_maj;
     uint32_t ret_min;
@@ -160,8 +160,12 @@ int main(int argc, const char *argv[])
     ret = 0;
 
 done:
+    gss_release_name(&ret_min, &user_name);
+    gss_release_name(&ret_min, &target_name);
     gss_release_buffer(&ret_min, &in_token);
     gss_release_buffer(&ret_min, &out_token);
     gss_release_cred(&ret_min, &cred_handle);
+    gss_delete_sec_context(&ret_min, &init_ctx, GSS_C_NO_BUFFER);
+    gss_delete_sec_context(&ret_min, &accept_ctx, GSS_C_NO_BUFFER);
     return ret;
 }

--- a/tests/t_utils.h
+++ b/tests/t_utils.h
@@ -15,9 +15,11 @@
 #define discard_const(ptr) ((void *)((uintptr_t)(ptr)))
 
 #define DEBUG(...) do { \
-    char msg[4096]; \
-    snprintf(msg, 4096, __VA_ARGS__); \
-    fprintf(stderr, "%s[%s:%d]: %s", argv[0], __FUNCTION__, __LINE__, msg); \
+    char _msg[4096]; \
+    int _snret; \
+    _snret = snprintf(_msg, 4096, __VA_ARGS__); \
+    fprintf(stderr, "%s[%s:%d]: %s", argv[0], __FUNCTION__, __LINE__, _msg); \
+    if (_snret >= 4096) fprintf(stderr, " [TRUNCATED]\n"); \
     fflush(stderr); \
 } while(0);
 


### PR DESCRIPTION
Return OIDs as static from SPI functions as expected by GSSAPI
Fix a bunch of leaks as reported by #11

Also improve how we handle reloads or waiting by avoiding arbitrary sleeps, although this did not help with the two tests failing under valgrind as hoped.

Fixes #9 
Fixes #11 