### PR TITLE
Add a hidden debug tool to gssproxy

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -178,6 +178,7 @@ gssproxy_SOURCES = \
     src/gp_rpc_wrap.c \
     src/gp_rpc_unwrap.c \
     src/gp_rpc_wrap_size_limit.c \
+    src/extract_ccache.c \
     src/gssproxy.c
 
 proxymech_la_SOURCES = \

--- a/src/extract_ccache.c
+++ b/src/extract_ccache.c
@@ -1,0 +1,134 @@
+/* Copyright (C) 2020 the GSS-PROXY contributors, see COPYING for license */
+
+#include "config.h"
+#include <stdint.h>
+#include <stdio.h>
+#include <stdbool.h>
+#include <errno.h>
+#include <string.h>
+#include "gp_proxy.h"
+#include <gssapi/gssapi_krb5.h>
+
+int extract_ccache(char *ccache_name, char *dest_ccache)
+{
+    krb5_context ctx = NULL;
+    krb5_ccache ccache = NULL;
+    krb5_creds cred = { 0 };
+    krb5_creds icred = { 0 };
+    krb5_enc_data enc_handle = { 0 };
+    krb5_data data_out = { 0 };
+    krb5_error_code ret;
+    gssx_cred xcred = { 0 };
+    XDR xdrctx;
+    bool xdrok;
+    struct gp_creds_handle *handle = NULL;
+    gss_buffer_desc token = GSS_C_EMPTY_BUFFER;
+    gss_cred_id_t gcred = NULL;
+    gss_key_value_element_desc element;
+    gss_key_value_set_desc store;
+    gss_key_value_set_desc *store_p = NULL;
+    uint32_t ret_maj = GSS_S_COMPLETE;
+    uint32_t ret_min = 0;
+    uint8_t pad;
+    size_t last_byte;
+    size_t i;
+
+    ret = krb5_init_context(&ctx);
+    if (ret) goto done;
+
+    ret = krb5_cc_resolve(ctx, ccache_name, &ccache);
+    if (ret) goto done;
+
+    ret = krb5_cc_get_principal(ctx, ccache, &icred.client);
+    if (ret) goto done;
+
+    ret = krb5_parse_name(ctx, GPKRB_SRV_NAME, &icred.server);
+    if (ret) goto done;
+
+    ret = krb5_cc_retrieve_cred(ctx, ccache, 0, &icred, &cred);
+    if (ret) goto done;
+
+    xdrmem_create(&xdrctx, cred.ticket.data, cred.ticket.length, XDR_DECODE);
+    xdrok = xdr_gssx_cred(&xdrctx, &xcred);
+    if (!xdrok) {
+        ret = EIO;
+        goto done;
+    }
+
+    ret_maj = gp_init_creds_handle(&ret_min, "Extract Ccache", NULL, &handle);
+    if (ret_maj) {
+        ret = ret_min;
+        goto done;
+    }
+
+    enc_handle.enctype = handle->key->enctype;
+    enc_handle.ciphertext.data =
+        xcred.cred_handle_reference.octet_string_val;
+    enc_handle.ciphertext.length =
+        xcred.cred_handle_reference.octet_string_len;
+
+    data_out.length = enc_handle.ciphertext.length;
+    data_out.data = malloc(enc_handle.ciphertext.length);
+    if (!data_out.data) {
+        ret = ENOMEM;
+        goto done;
+    }
+
+    ret = krb5_c_decrypt(handle->context, handle->key,
+                         KRB5_KEYUSAGE_APP_DATA_ENCRYPT,
+                         NULL, &enc_handle, &data_out);
+    if (ret) goto done;
+    fprintf(stderr, "decrypted\n");
+
+    /* Handle the padding. */
+    last_byte = data_out.length - 1;
+    pad = data_out.data[last_byte];
+    if (pad >= ENC_MIN_PAD_LEN && pad < last_byte) {
+        for (i = last_byte - pad; i <= last_byte; i++) {
+            if (pad != data_out.data[i]) break;
+        }
+        if (i == last_byte) {
+            /* they all match, this is padding, remove it */
+            data_out.length -= pad;
+        }
+    }
+
+    token.value = data_out.data;
+    token.length = data_out.length;
+    ret_maj = gss_import_cred(&ret_min, &token, &gcred);
+    if (ret_maj) {
+        gp_log_failure(GSS_C_NULL_OID, ret_maj, ret_min);
+        ret = ret_min;
+        goto done;
+    }
+
+    /* store in destination ccache if any, or default ccache */
+    if (dest_ccache) {
+        element.key = "ccache";
+        element.value = dest_ccache;
+        store.elements = &element;
+        store.count = 1;
+        store_p = &store;
+    }
+
+    ret_maj = gss_store_cred_into(&ret_min, gcred, GSS_C_BOTH,
+                                  GSS_C_NULL_OID, 1, 1, store_p, NULL, NULL);
+    if (ret_maj) {
+        gp_log_failure(GSS_C_NULL_OID, ret_maj, ret_min);
+        ret = ret_min;
+        goto done;
+    }
+
+done:
+    if (ctx) {
+        krb5_free_cred_contents(ctx, &cred);
+        krb5_free_cred_contents(ctx, &icred);
+        if (ccache) krb5_cc_close(ctx, ccache);
+        krb5_free_context(ctx);
+    }
+    xdr_free((xdrproc_t)xdr_gssx_cred, (char *)&xcred);
+    gp_free_creds_handle(&handle);
+    gss_release_cred(&ret_min, &gcred);
+    free(data_out.data);
+    return ret;
+}

--- a/src/gp_common.h
+++ b/src/gp_common.h
@@ -40,6 +40,9 @@
     ptr = NULL; \
 } while(0)
 
+#define GPKRB_SRV_NAME "Encrypted/Credentials/v1@X-GSSPROXY:"
+#define ENC_MIN_PAD_LEN 8
+
 /* max out at 1MB for now */
 #define MAX_RPC_SIZE 1024*1024
 

--- a/src/gp_export.c
+++ b/src/gp_export.c
@@ -9,17 +9,11 @@
 #include "gp_export.h"
 #include "gp_debug.h"
 #include "gp_proxy.h"
-#include <gssapi/gssapi_krb5.h>
 #include <pwd.h>
 #include <grp.h>
 #include <pthread.h>
 
 #define GP_CREDS_HANDLE_KEY_ENCTYPE ENCTYPE_AES256_CTS_HMAC_SHA1_96
-
-struct gp_creds_handle {
-    krb5_context context;
-    krb5_keyblock *key;
-};
 
 void gp_free_creds_handle(struct gp_creds_handle **in)
 {
@@ -192,8 +186,6 @@ done:
 
     return ret_maj;
 }
-
-#define ENC_MIN_PAD_LEN 8
 
 /* We need to pad our payloads because krb5_c_decrypt() may pad the
  * contents for some enctypes, and gss_import_cred() doesn't like

--- a/src/gp_proxy.h
+++ b/src/gp_proxy.h
@@ -7,6 +7,7 @@
 #include <stdbool.h>
 #include <stdint.h>
 #include <gssapi/gssapi_ext.h>
+#include <gssapi/gssapi_krb5.h>
 #include "verto.h"
 #include "gp_common.h"
 #include "gp_selinux.h"
@@ -18,7 +19,10 @@
 
 #define GP_CRED_KRB5    0x01
 
-struct gp_creds_handle;
+struct gp_creds_handle {
+    krb5_context context;
+    krb5_keyblock *key;
+};
 
 struct gp_cred_krb5 {
     char *principal;
@@ -143,5 +147,7 @@ uint32_t gp_init_creds_handle(uint32_t *min, const char *svc_name,
                               const char *keytab,
                               struct gp_creds_handle **out);
 void gp_free_creds_handle(struct gp_creds_handle **in);
+
+int extract_ccache(char *ccache_name, char *dest_ccache);
 
 #endif /* _GP_PROXY_H_ */

--- a/src/gssproxy.c
+++ b/src/gssproxy.c
@@ -15,6 +15,8 @@ const int vflags =
 char *opt_config_file = NULL;
 char *opt_config_dir = NULL;
 char *opt_config_socket = NULL;
+char *opt_extract_ccache = NULL;
+char *opt_dest_ccache = NULL;
 int opt_daemon = 0;
 
 struct gssproxy_ctx *gpctx;
@@ -193,6 +195,12 @@ int main(int argc, const char *argv[])
          _("Enable GSSAPI status logging to syslog"), NULL}, \
         {"version", '\0', POPT_ARG_NONE, &opt_version, 0, \
          _("Print version number and exit"), NULL }, \
+        {"extract-ccache", '\0', POPT_ARG_STRING|POPT_ARGFLAG_DOC_HIDDEN, \
+         &opt_extract_ccache, 0, \
+        _("Extract a gssproxy encrypted ccache"), NULL },
+        {"into-ccache", '\0', POPT_ARG_STRING|POPT_ARGFLAG_DOC_HIDDEN, \
+        &opt_dest_ccache, 0, \
+        _("Destination ccache for extracted ccache"), NULL },
         POPT_TABLEEND
     };
 
@@ -218,6 +226,11 @@ int main(int argc, const char *argv[])
     if (opt_debug || opt_debug_level > 0) {
         if (opt_debug_level == 0) opt_debug_level = 1;
         gp_debug_toggle(opt_debug_level);
+    }
+
+    if (opt_extract_ccache) {
+        ret = extract_ccache(opt_extract_ccache, opt_dest_ccache);
+        goto cleanup;
     }
 
     if (opt_syslog_status)
@@ -325,6 +338,8 @@ cleanup:
     free(opt_config_file);
     free(opt_config_dir);
     free(opt_config_socket);
+    free(opt_extract_ccache);
+    free(opt_dest_ccache);
 
 #ifdef HAVE_VERTO_CLEANUP
     verto_cleanup();

--- a/src/mechglue/gpp_creds.c
+++ b/src/mechglue/gpp_creds.c
@@ -3,8 +3,6 @@
 #include "gss_plugin.h"
 #include <gssapi/gssapi_krb5.h>
 
-#define GPKRB_SRV_NAME "Encrypted/Credentials/v1@X-GSSPROXY:"
-
 uint32_t gpp_cred_handle_init(uint32_t *min, bool defcred, const char *ccache,
                               struct gpp_cred_handle **out_handle)
 {


### PR DESCRIPTION
Sometimes it is really valuable to be able to extract the ccaches that a
client may be storing encrypted.

This special tool allows that and can be used as follow:

KRB5CCNAME=~/decryptedccache KRB5_KTNAME=/path/to/service.keytab ./gssproxy -d --extract-ccache /path/to/encrypted.ccache

Then using a file ccache as the default ccache, the ccache must be
initialized first with something like kinit and then the decrypted
contents will be appended to it. It doesn't matter what creedntials are
used for the kinit part.