### PR TITLE
Update EXTRA_DIST for missing test files

### DIFF
--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -71,7 +71,10 @@ EXTRA_DIST = \
     t_impersonate.py \
     t_interpose.py \
     t_multi_key.py \
+    t_names.py \
+    t_program.py \
     t_reloading.py \
+    t_setcredopt.py \
     $(NULL)
 
 all: $(check_PROGRAMS)


### PR DESCRIPTION
- t_names.py was added in 27bf21cc119005e0e6d9f1d58592408b5cd6337c
- t_program.py was added in f61449b0212170d1dd619738e243e8f409ea161c
- t_setcredopt.py was added in 8572a84778e1bae74fbc396d4b9922b490ee2837

Signed-off-by: Robbie Harwood <rharwood@redhat.com>