### PR TITLE
Add min lifetime option

### DIFF
--- a/examples/99-nfs-client.conf.in
+++ b/examples/99-nfs-client.conf.in
@@ -7,3 +7,4 @@
   allow_any_uid = yes
   trusted = yes
   euid = 0
+  min_lifetime = 60

--- a/man/gssproxy.conf.5.xml
+++ b/man/gssproxy.conf.5.xml
@@ -332,6 +332,21 @@
                 </varlistentry>
 
                 <varlistentry>
+                    <term>min_lifetime (integer)</term>
+                    <listitem>
+                        <para>Minimum lifetime of a cached credential, in seconds.</para>
+                        <para>If non-zero, when gssproxy is deciding whether to use
+                            a cached credential, it will compare the lifetime of the
+                            cached credential to this value.  If the lifetime of the
+                            cached credential is lower, gssproxy will treat the cached
+                            credential as expired and will attempt to obtain a new
+                            credential.
+                        </para>
+                        <para>Default: min_lifetime = 15</para>
+                    </listitem>
+                </varlistentry>
+
+                <varlistentry>
                     <term>program (string)</term>
                     <listitem>
                         <para>If specified, this service will only match when

--- a/src/gp_config.c
+++ b/src/gp_config.c
@@ -32,6 +32,7 @@ struct gp_flag_def flag_names[] = {
 
 #define DEFAULT_FILTERED_FLAGS GSS_C_DELEG_FLAG
 #define DEFAULT_ENFORCED_FLAGS 0
+#define DEFAULT_MIN_LIFETIME 15
 
 static void free_str_array(const char ***a, int *count)
 {
@@ -536,6 +537,17 @@ static int load_services(struct gp_config *cfg, struct gp_ini_context *ctx)
                 if (!cfg->svcs[n]->program) {
                     ret = ENOMEM;
                     goto done;
+                }
+            }
+
+            cfg->svcs[n]->min_lifetime = DEFAULT_MIN_LIFETIME;
+            ret = gp_config_get_int(ctx, secname, "min_lifetime", &valnum);
+            if (ret == 0) {
+                if (valnum >= 0) {
+                    cfg->svcs[n]->min_lifetime = valnum;
+                } else {
+                    GPDEBUG("Invalid value '%d' for min_lifetime in [%s], ignoring.\n",
+                            valnum, secname);
                 }
             }
         }

--- a/src/gp_config.c
+++ b/src/gp_config.c
@@ -611,6 +611,8 @@ int load_config(struct gp_config *cfg)
         goto done;
     }
 
+    gp_debug_toggle(tmp_dbg_lvl);
+
     ret = gp_config_get_string(ctx, "gssproxy", "syslog_status", &tmpstr);
     if (ret == 0)
         gp_syslog_status = gp_boolean_is_true(tmpstr);
@@ -640,7 +642,6 @@ done:
     if (ret != 0) {
         GPERROR("Error reading configuration %d: %s", ret, gp_strerror(ret));
     }
-    gp_debug_toggle(tmp_dbg_lvl);
     gp_config_close(ctx);
     safefree(ctx);
     return ret;

--- a/src/gp_proxy.h
+++ b/src/gp_proxy.h
@@ -45,6 +45,7 @@ struct gp_service {
     gss_cred_usage_t cred_usage;
     uint32_t filter_flags;
     uint32_t enforce_flags;
+    uint32_t min_lifetime;
     char *program;
 
     uint32_t mechs;


### PR DESCRIPTION
It's possible for gssproxy to return a cached credential with a very small remaining lifetime.  This can be problematic for NFS clients since it requires a round trip to the NFS server to establish a GSS context. Add a min_lifetime option that represents the lowest value that the lifetime of the cached credential can be.  Any lower than that, and gp_check_cred() returns GSS_S_CREDENTIALS_EXPIRED, so that gp_add_krb5_creds() is forced to try to obtain a new credential.

This fixes an issue where NFS clients (particularly ones using the interposer mechanism) can receive EKEYEXPIRED/EACCES/EIO at the time of Kerberos ticket expiration.

Also, fix an issue where debug messages aren't getting logged during config parsing.