### PR TITLE
Change nfs-client to network-fs-clients

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -244,7 +244,7 @@ noinst_DATA = \
     examples/gssproxy.conf \
     examples/24-nfs-server.conf \
     examples/80-httpd.conf \
-    examples/99-nfs-client.conf \
+    examples/99-network-fs-clients.conf \
     examples/mech
 
 edit_cmd = $(SED) \
@@ -265,7 +265,7 @@ EXTRA_DIST = \
     examples/gssproxy.conf.in \
     examples/24-nfs-server.conf.in \
     examples/80-httpd.conf.in \
-    examples/99-nfs-client.conf.in \
+    examples/99-network-fs-clients.conf.in \
     examples/mech.in
 
 systemd/gssproxy.service: systemd/gssproxy.service.in Makefile
@@ -317,7 +317,7 @@ CLEANFILES = *.X */*.X */*/*.X \
     examples/gssproxy.conf \
     examples/24-nfs-server.conf \
     examples/80-httpd.conf \
-    examples/99-nfs-client.conf \
+    examples/99-network-fs-clients.conf \
     systemd/gssproxy.service
 
 check: all $(check_PROGRAMS)

--- a/contrib/gssproxy.spec.in
+++ b/contrib/gssproxy.spec.in
@@ -73,7 +73,7 @@ rm -f %{buildroot}%{_libdir}/gssproxy/proxymech.la
 install -d -m755 %{buildroot}%{_sysconfdir}/gssproxy
 install -m644 examples/gssproxy.conf %{buildroot}%{_sysconfdir}/gssproxy/gssproxy.conf
 install -m644 examples/24-nfs-server.conf %{buildroot}%{_sysconfdir}/gssproxy/24-nfs-server.conf
-install -m644 examples/99-nfs-client.conf %{buildroot}%{_sysconfdir}/gssproxy/99-nfs-client.conf
+install -m644 examples/99-network-fs-clients.conf %{buildroot}%{_sysconfdir}/gssproxy/99-network-fs-clients.conf
 mkdir -p %{buildroot}%{_sysconfdir}/gss/mech.d
 install -m644 examples/mech %{buildroot}%{_sysconfdir}/gss/mech.d/gssproxy.conf
 mkdir -p %{buildroot}%{gpstatedir}/rcache
@@ -93,7 +93,7 @@ rm -rf %{buildroot}
 %attr(700,root,root) %dir %{gpstatedir}/rcache
 %attr(0600,root,root) %config(noreplace) /%{_sysconfdir}/gssproxy/gssproxy.conf
 %attr(0600,root,root) %config(noreplace) /%{_sysconfdir}/gssproxy/24-nfs-server.conf
-%attr(0600,root,root) %config(noreplace) /%{_sysconfdir}/gssproxy/99-nfs-client.conf
+%attr(0600,root,root) %config(noreplace) /%{_sysconfdir}/gssproxy/99-network-fs-clients.conf
 %attr(0644,root,root) %config(noreplace) /%{_sysconfdir}/gss/mech.d/gssproxy.conf
 %{_libdir}/gssproxy/proxymech.so
 %{_mandir}/man5/gssproxy.conf.5*

--- a/docs/network_fs_clients.md
+++ b/docs/network_fs_clients.md
@@ -1,0 +1,40 @@
+# Introduction
+
+Following changes to cifs.upcall, extending its functionality to leverage gssapi for ticket acquisition, 99-nfs-client.conf has been renamed to 99-network-fs-clients.conf. This allows the upcall programs for client side NFS and SMB, rpc.gssd and cifs.upcall, to leverage the same configuration file. However, there may be circumstances where having differentiated access for each remote filesystem is preferred or even necessary.
+
+## Creating configuration files
+
+If different behavior for client side NFS and SMB is needed:
+
+1) Remove /etc/gssproxy/99-network-fs-clients.conf
+
+2) Create configuration files for cifs-client and nfs-client services. The `program =` option **must** be included if both programs are going to access the default socket, `/var/lib/gssproxy/default.sock`
+
+~~~~
+# cat /etc/gssproxy/99-cifs-client.conf
+[service/cifs-client]
+  mechs = krb5
+  cred_store = keytab:/etc/krb5.keytab
+  cred_store = ccache:FILE:/var/lib/gssproxy/clients/krb5cc_%U
+  cred_store = client_keytab:/var/lib/gssproxy/clients/%U.keytab
+  cred_usage = initiate
+  allow_any_uid = yes
+  trusted = yes
+  euid = 0
+  program = /usr/sbin/cifs.upcall
+~~~~
+
+~~~~
+[service/nfs-client]
+  mechs = krb5
+  cred_store = keytab:/etc/krb5.keytab
+  cred_store = ccache:FILE:/var/lib/gssproxy/clients/krb5cc_%U
+  cred_store = client_keytab:/var/lib/gssproxy/clients/%U.keytab
+  cred_usage = initiate
+  allow_any_uid = yes
+  trusted = yes
+  euid = 0
+  program = /usr/sbin/rpc.gssd
+~~~~
+
+3) Customize the above files as needed. The existing docs/NFS.md file discusses Keytab based Client initiation as well as User Impersonation and Constrainted Delegation. Resource Base Constrained Delegation is also possible and requires no additional client side configuration changes as RBCD is a server side configuration change.

--- a/examples/99-network-fs-clients.conf.in
+++ b/examples/99-network-fs-clients.conf.in
@@ -1,4 +1,4 @@
-[service/nfs-client]
+[service/network-fs-clients]
   mechs = krb5
   cred_store = keytab:/etc/krb5.keytab
   cred_store = ccache:FILE:@gpclidir@/krb5cc_%U


### PR DESCRIPTION
Proposed patches for cifs.upcall extending the binary to leverage gssapi have been slated for inclusion into cifs-utils. A drop file for gssproxy is needed to go along with the patch. The drop file is a near match for nfs-client with the difference in the "program" option. Both cifs-client and nfs-client can use the same default socket, but the configuration files need to be distinguished otherwise gssproxy will not start.

Proposing "cifs-client" drop file to go along with patches and modifying the existing "nfs-client" drop file so that it can continue to work.

Link for cifs.upcall patch as discussed above:
https://github.com/piastry/cifs-utils/commit/3d681bb5c140376ccc19e48711231aeef1e87aa9