### PR TITLE
Add missing #include for musl

### DIFF
--- a/src/gp_socket.c
+++ b/src/gp_socket.c
@@ -10,6 +10,7 @@
 #include <fcntl.h>
 #include <netinet/in.h>
 #include <stdlib.h>
+#include <string.h>
 #include <sys/socket.h>
 #include <sys/stat.h>
 #include <sys/types.h>


### PR DESCRIPTION
Bug: https://bugs.gentoo.org/719920

Signed-off-by: David Seifert <soap@gentoo.org>