### PR TITLE
Add self-termination for user mode.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,6 +39,7 @@ cli_srv_conn
 cli_srv_comm
 gssproxy.spec
 interposetest
+userproxytest
 gssproxy.service
 gssuserproxy.service
 gssuserproxy.socket

--- a/Makefile.am
+++ b/Makefile.am
@@ -370,6 +370,10 @@ CLEANFILES = *.X */*.X */*/*.X \
 
 check: all $(check_PROGRAMS)
 	$(srcdir)/tests/runtests.py $(CHECKARGS)
+if HAVE_SYSTEMD_DAEMON
+	mkdir -p testdir
+	tests/userproxytest
+endif
 
 tests: check
 

--- a/external/systemd.m4
+++ b/external/systemd.m4
@@ -23,4 +23,6 @@ AC_DEFUN([AM_CHECK_SYSTEMD],
               [AC_MSG_NOTICE([Build without $daemon_lib_name support])])],
           [AC_MSG_NOTICE([Build without $daemon_lib_name support])])
 
+    AM_CONDITIONAL([HAVE_SYSTEMD_DAEMON], [test x"$daemon_lib_name" != x])
+    AC_MSG_NOTICE([Will enable systemd socket activation])
 ])

--- a/src/gp_init.c
+++ b/src/gp_init.c
@@ -113,12 +113,6 @@ void fini_server(void)
     closelog();
 }
 
-static void break_loop(verto_ctx *vctx, verto_ev *ev UNUSED)
-{
-    GPDEBUG("Exiting after receiving a signal\n");
-    verto_break(vctx);
-}
-
 verto_ctx *init_event_loop(void)
 {
     verto_ctx *vctx;

--- a/src/gp_proxy.h
+++ b/src/gp_proxy.h
@@ -74,6 +74,10 @@ struct gssproxy_ctx {
     struct gp_workers *workers;
     verto_ctx *vctx;
     verto_ev *sock_ev;      /* default socket event */
+
+    bool terminate;     /* program runs while this is false */
+    time_t term_timeout;
+    verto_ev *term_ev; /* termination ev in user mode */
 };
 
 struct gp_sock_ctx {
@@ -105,6 +109,7 @@ void init_server(bool daemonize, int userproxy, int *wait_fd);
 void init_done(int wait_fd);
 void fini_server(void);
 verto_ctx *init_event_loop(void);
+void break_loop(verto_ctx *, verto_ev *);
 void init_proc_nfsd(struct gp_config *cfg);
 void write_pid(void);
 int drop_privs(struct gp_config *cfg);

--- a/src/gp_socket.c
+++ b/src/gp_socket.c
@@ -217,6 +217,9 @@ int init_activation_socket(struct gssproxy_ctx *gpctx,
         _sock_ctx->fd = fd;
 
         *sock_ctx = _sock_ctx;
+    } else {
+        /* disable self termination as we are not socket activated */
+        gpctx->term_timeout = 0;
     }
 
 done:

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -57,6 +57,13 @@ check_PROGRAMS = \
     t_setcredopt \
     $(NULL)
 
+if HAVE_SYSTEMD_DAEMON
+userproxytest_SOURCES = \
+    userproxytest.c
+
+    check_PROGRAMS += userproxytest
+endif
+
 noinst_PROGRAMS = $(check_PROGRAMS)
 
 noinst_HEADERS = \

--- a/tests/userproxytest.c
+++ b/tests/userproxytest.c
@@ -1,0 +1,90 @@
+/* Copyright (C) 2022 the GSS-PROXY contributors, see COPYING for license */
+
+#define _GNU_SOURCE
+#include <stdio.h>
+#include <stdlib.h>
+#include <sys/socket.h>
+#include <sys/un.h>
+#include <sys/wait.h>
+#include <unistd.h>
+
+char *srv_args[] = {
+    "./gssproxy",
+    "-u", "-i",
+    "-s", "./testdir/userproxytest.sock",
+    "--idle-timeout=3"
+};
+
+int mock_activation_sockets(void)
+{
+    struct sockaddr_un addr = {
+        .sun_family = AF_UNIX,
+        .sun_path = "./testdir/userproxytest.sock",
+    };
+    int fd;
+    int ret;
+
+    unlink(addr.sun_path);
+
+    fd = socket(AF_UNIX, SOCK_STREAM, 0);
+    if (fd == -1) return -1;
+
+    ret = bind(fd, (struct sockaddr *)&addr, sizeof(addr));
+    if (ret == -1) return -1;
+
+    ret = listen(fd, 1);
+    if (ret == -1) return -1;
+
+    return 0;
+}
+
+int mock_activation_environment(void)
+{
+    char *onestr = "1";
+    char *pidstr;
+    int ret;
+
+    ret = asprintf(&pidstr, "%u", (unsigned)getpid());
+    if (ret == -1) return -1;
+
+    setenv("LISTEN_PID", pidstr, 1);
+    setenv("LISTEN_FDS", onestr, 1);
+
+    free(pidstr);
+    return 0;
+}
+
+int main(int argc, const char *main_argv[])
+{
+    pid_t proxy, w;
+    int ret;
+
+    fprintf(stderr, "Test userproxy mode: ");
+
+    ret = mock_activation_sockets();
+    if (ret) return -1;
+
+    proxy = fork();
+    if (proxy == -1) return -1;
+
+    if (proxy == 0) {
+        ret = mock_activation_environment();
+        if (ret) return -1;
+
+        execv("./gssproxy", srv_args);
+        return -1;
+    }
+
+    sleep(6);
+
+    w = waitpid(-1, &ret, WNOHANG);
+    if (w != proxy || ret != 0) {
+        fprintf(stderr, "FAIL\n");
+        fflush(stderr);
+        return -1;
+    }
+
+    fprintf(stderr, "SUCCESS\n");
+    fflush(stderr);
+    return 0;
+}


### PR DESCRIPTION
Self termination kicks in only if the daemon is socket activated, so
that the user daemon eventually turns itself off when not used.

The default timeout is 1000 seconds but can be changed via the command
line switch --idle-timeout

Fixes #47 