### PR TITLE
Refactor initialization and self termination code

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -173,6 +173,7 @@ if BUILD_PROXY
 gssproxy_SOURCES = \
     src/gp_config.c \
     src/gp_init.c \
+    src/gp_mgmt.c \
     src/gp_socket.c \
     src/gp_workers.c \
     src/gp_creds.c \

--- a/src/gp_debug.h
+++ b/src/gp_debug.h
@@ -8,6 +8,8 @@
 #include <stdio.h>
 #include <time.h>
 
+#define GP_INFO_DEBUG_LVL 1
+
 extern int gp_debug;
 
 void gp_debug_toggle(int);

--- a/src/gp_init.c
+++ b/src/gp_init.c
@@ -113,6 +113,12 @@ void fini_server(void)
     closelog();
 }
 
+static void break_loop(verto_ctx *vctx, verto_ev *ev UNUSED)
+{
+    GPDEBUG("Exiting after receiving a signal\n");
+    verto_break(vctx);
+}
+
 verto_ctx *init_event_loop(void)
 {
     verto_ctx *vctx;

--- a/src/gp_init.c
+++ b/src/gp_init.c
@@ -344,6 +344,33 @@ fail:
     }
 }
 
+/* Schedule an event to run as soon as the event loop is started
+ * This is also useful in debugging to know that all initialization
+ * is done. */
+static void delayed_init(verto_ctx *vctx UNUSED, verto_ev *ev)
+{
+    struct gssproxy_ctx *gpctx;
+
+    GPDEBUG("Initialization complete.\n");
+
+    gpctx = verto_get_private(ev);
+    idle_handler(gpctx);
+}
+
+int init_event_fini(struct gssproxy_ctx *gpctx)
+{
+    verto_ev *ev;
+
+    ev = verto_add_timeout(gpctx->vctx, VERTO_EV_FLAG_NONE, delayed_init, 1);
+    if (!ev) {
+        fprintf(stderr, "Failed to register delayed_init event!\n");
+        return EXIT_FAILURE;
+    }
+    verto_set_private(ev, gpctx, NULL);
+
+    return 0;
+}
+
 void init_proc_nfsd(struct gp_config *cfg)
 {
     char buf[] = "1";

--- a/src/gp_mgmt.c
+++ b/src/gp_mgmt.c
@@ -1,0 +1,36 @@
+/* Copyright (C) 2022 the GSS-PROXY contributors, see COPYING for license */
+
+#include "config.h"
+#include "gp_proxy.h"
+
+static void idle_terminate(verto_ctx *vctx, verto_ev *ev)
+{
+    struct gssproxy_ctx *gpctx = verto_get_private(ev);
+
+    GPDEBUG("Terminating, after idling for %ld seconds!\n",
+            (long)gpctx->term_timeout/1000);
+    verto_break(vctx);
+}
+
+void idle_handler(struct gssproxy_ctx *gpctx)
+{
+    /* we've been called, this means some event just fired,
+     * restart the timeout handler */
+
+    if (gpctx->term_timeout == 0) {
+        /* self termination is disabled */
+        return;
+    }
+
+    verto_del(gpctx->term_ev);
+
+    /* Add self-termination timeout */
+    gpctx->term_ev = verto_add_timeout(gpctx->vctx, VERTO_EV_FLAG_NONE,
+                                       idle_terminate, gpctx->term_timeout);
+    if (!gpctx->term_ev) {
+        GPDEBUG("Failed to register timeout event!\n");
+    }
+    verto_set_private(gpctx->term_ev, gpctx, NULL);
+}
+
+

--- a/src/gp_proxy.h
+++ b/src/gp_proxy.h
@@ -83,6 +83,10 @@ struct gssproxy_ctx {
 
     time_t term_timeout;
     verto_ev *term_ev; /* termination ev in user mode */
+
+    ssize_t readstats;
+    ssize_t writestats;
+    time_t last_activity;
 };
 
 struct gp_sock_ctx {
@@ -127,6 +131,8 @@ int clear_bound_caps(void);
 
 /* from gp_mgmt.c */
 void idle_handler(struct gssproxy_ctx *gpctx);
+void gp_activity_accounting(struct gssproxy_ctx *gpctx,
+                            ssize_t rb, ssize_t wb);
 
 /* from gp_socket.c */
 void free_unix_socket(verto_ctx *ctx, verto_ev *ev);

--- a/src/gp_proxy.h
+++ b/src/gp_proxy.h
@@ -117,12 +117,16 @@ int init_sockets(struct gssproxy_ctx *gpctx, struct gp_config *old_config);
 int init_userproxy_socket(struct gssproxy_ctx *gpctx);
 void init_event_loop(struct gssproxy_ctx *gpctx);
 void init_proc_nfsd(struct gp_config *cfg);
+int init_event_fini(struct gssproxy_ctx *gpctx);
 void write_pid(void);
 int drop_privs(struct gp_config *cfg);
 #ifdef HAVE_CAP
 int drop_caps(void);
 int clear_bound_caps(void);
 #endif
+
+/* from gp_mgmt.c */
+void idle_handler(struct gssproxy_ctx *gpctx);
 
 /* from gp_socket.c */
 void free_unix_socket(verto_ctx *ctx, verto_ev *ev);

--- a/src/gp_proxy.h
+++ b/src/gp_proxy.h
@@ -75,7 +75,6 @@ struct gssproxy_ctx {
     verto_ctx *vctx;
     verto_ev *sock_ev;      /* default socket event */
 
-    bool terminate;     /* program runs while this is false */
     time_t term_timeout;
     verto_ev *term_ev; /* termination ev in user mode */
 };
@@ -109,7 +108,6 @@ void init_server(bool daemonize, int userproxy, int *wait_fd);
 void init_done(int wait_fd);
 void fini_server(void);
 verto_ctx *init_event_loop(void);
-void break_loop(verto_ctx *, verto_ev *);
 void init_proc_nfsd(struct gp_config *cfg);
 void write_pid(void);
 int drop_privs(struct gp_config *cfg);

--- a/src/gp_proxy.h
+++ b/src/gp_proxy.h
@@ -70,6 +70,12 @@ struct gp_config {
 struct gp_workers;
 
 struct gssproxy_ctx {
+    bool userproxymode;
+    char *config_file;
+    char *config_dir;
+    char *config_socket;
+    int daemonize;
+
     struct gp_config *config;
     struct gp_workers *workers;
     verto_ctx *vctx;
@@ -107,7 +113,9 @@ struct gp_config *userproxy_config(char *socket_name, int opt_daemonize);
 void init_server(bool daemonize, int userproxy, int *wait_fd);
 void init_done(int wait_fd);
 void fini_server(void);
-verto_ctx *init_event_loop(void);
+int init_sockets(struct gssproxy_ctx *gpctx, struct gp_config *old_config);
+int init_userproxy_socket(struct gssproxy_ctx *gpctx);
+void init_event_loop(struct gssproxy_ctx *gpctx);
 void init_proc_nfsd(struct gp_config *cfg);
 void write_pid(void);
 int drop_privs(struct gp_config *cfg);

--- a/tests/userproxytest.c
+++ b/tests/userproxytest.c
@@ -1,16 +1,20 @@
 /* Copyright (C) 2022 the GSS-PROXY contributors, see COPYING for license */
 
 #define _GNU_SOURCE
+#include <fcntl.h>
+#include <stdbool.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <sys/socket.h>
 #include <sys/un.h>
 #include <sys/wait.h>
+#include <time.h>
 #include <unistd.h>
 
 char *srv_args[] = {
     "./gssproxy",
     "-u", "-i",
+    "-d", "--debug-level=1",
     "-s", "./testdir/userproxytest.sock",
     "--idle-timeout=3"
 };
@@ -54,34 +58,122 @@ int mock_activation_environment(void)
     return 0;
 }
 
+int wait_and_check_output(int outfd, int timeout)
+{
+    struct {
+        const char *match;
+        bool matched;
+    } checks[] = {
+        { "Initialization complete.", false },
+        { "Terminating, after idling", false },
+        { NULL, true }
+    };
+    time_t start = time(NULL);
+    time_t now = start;
+    useconds_t interval = 100 * 1000; /* 100 msec */
+    char outbuf[1024];
+    char *line;
+    FILE *out;
+    int ret;
+
+    /* make pipe non blocking */
+    ret = fcntl(outfd, F_SETFL, O_NONBLOCK);
+    if (ret) return -1;
+
+    out = fdopen(outfd, "r");
+    if (!out) return -1;
+
+    while (now < start + timeout) {
+        ret = usleep(interval);
+        if (ret) return -1;
+
+        line = fgets(outbuf, 1023, out);
+        if (line) {
+            for (int i = 0; checks[i].match != NULL; i++) {
+                if (strstr(line, checks[i].match)) {
+                    checks[i].matched = true;
+                }
+            }
+        }
+
+        now = time(NULL);
+    }
+
+    fclose(out);
+
+    for (int i = 0; checks[i].match != NULL; i++) {
+        if (checks[i].matched == false) return -1;
+    }
+
+    return 0;
+}
+
+int child(int outpipe[])
+{
+    int ret;
+
+    ret = mock_activation_environment();
+    if (ret) exit(EXIT_FAILURE);
+
+    close(outpipe[0]);
+    ret = dup2(outpipe[1], 2);
+    if (ret == -1) exit(EXIT_FAILURE);
+
+    execv("./gssproxy", srv_args);
+    exit(EXIT_FAILURE);
+}
+
 int main(int argc, const char *main_argv[])
 {
     pid_t proxy, w;
+    int outpipe[2];
     int ret;
 
     fprintf(stderr, "Test userproxy mode: ");
 
     ret = mock_activation_sockets();
-    if (ret) return -1;
-
-    proxy = fork();
-    if (proxy == -1) return -1;
-
-    if (proxy == 0) {
-        ret = mock_activation_environment();
-        if (ret) return -1;
-
-        execv("./gssproxy", srv_args);
-        return -1;
+    if (ret) {
+        ret = EXIT_FAILURE;
+        goto done;
     }
 
-    sleep(6);
+    ret = pipe(outpipe);
+    if (ret) {
+        ret = EXIT_FAILURE;
+        goto done;
+    }
+
+    proxy = fork();
+    if (proxy == -1) {
+        ret = EXIT_FAILURE;
+        goto done;
+    }
+
+    if (proxy == 0) {
+        child(outpipe);
+    }
+
+    close(outpipe[1]);
+
+    ret = wait_and_check_output(outpipe[0], 6);
+    if (ret) {
+        ret = EXIT_FAILURE;
+        goto done;
+    }
 
     w = waitpid(-1, &ret, WNOHANG);
     if (w != proxy || ret != 0) {
+        ret = EXIT_FAILURE;
+        goto done;
+    }
+
+    ret = 0;
+
+done:
+    if (ret) {
         fprintf(stderr, "FAIL\n");
         fflush(stderr);
-        return -1;
+        return ret;
     }
 
     fprintf(stderr, "SUCCESS\n");


### PR DESCRIPTION
Self termination was not happening if the timeout was larger than about 1 minute, due to the event loop self management which makes it return to the calling function regularly.
In order to ignore unimportnat events that wake up the event loop it means we cannot measure idleness from the event loop general activity but we need to do so via measuring actual significant events.

Actual activity happens when clients make requests, so use the socket reader events as signal to reset the idler event.

While there also gather some statistics that can be printed ad debug level 1 (INFO).