### PR TITLE
No idle timer when not socket activated

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -21,7 +21,7 @@ jobs:
             - name: Install dependencies
               run: |
                   sudo apt-get update
-                  sudo apt-get install -y build-essential autopoint clang gcc docbook-{xsl,xml} libxml2-utils xml-core xsltproc lib{krb5,ini-config,keyutils,popt,selinux1,verto}-dev lib{nss,socket}-wrapper python3{,-colorama} valgrind krb5-{kdc,admin-server,kdc-ldap} ldap-utils slapd apparmor-utils
+                  sudo apt-get install -y build-essential autopoint clang gcc docbook-{xsl,xml} libxml2-utils xml-core xsltproc lib{krb5,ini-config,keyutils,popt,selinux1,systemd,verto}-dev lib{nss,socket}-wrapper python3{,-colorama} valgrind krb5-{kdc,admin-server,kdc-ldap} ldap-utils slapd apparmor-utils
             - name: Silence AppArmor
               run: sudo aa-complain $(which slapd)
             - name: Setup

--- a/external/systemd.m4
+++ b/external/systemd.m4
@@ -19,10 +19,11 @@ AC_DEFUN([AM_CHECK_SYSTEMD],
               [SYSTEMD_DAEMON],
               [$daemon_lib_name],
               [AC_DEFINE_UNQUOTED([HAVE_SYSTEMD_DAEMON], 1,
-                                  [Build with $daemon_lib_name support])],
+                                  [Build with $daemon_lib_name support])
+
+               AC_MSG_NOTICE([Will enable systemd socket activation])],
               [AC_MSG_NOTICE([Build without $daemon_lib_name support])])],
           [AC_MSG_NOTICE([Build without $daemon_lib_name support])])
 
     AM_CONDITIONAL([HAVE_SYSTEMD_DAEMON], [test x"$daemon_lib_name" != x])
-    AC_MSG_NOTICE([Will enable systemd socket activation])
 ])

--- a/src/gp_init.c
+++ b/src/gp_init.c
@@ -151,6 +151,9 @@ static verto_ev *setup_socket(struct gssproxy_ctx *gpctx, char *sock_name,
     }
 #endif
     if (!sock_ctx) {
+        /* disable self termination as we are not socket activated */
+        gpctx->term_timeout = 0;
+
         /* no activation, try regular socket creation */
         sock_ctx = init_unix_socket(gpctx, sock_name);
     }

--- a/src/gp_mgmt.c
+++ b/src/gp_mgmt.c
@@ -28,7 +28,7 @@ void idle_handler(struct gssproxy_ctx *gpctx)
     /* we've been called, this means some event just fired,
      * restart the timeout handler */
 
-    if (gpctx->term_timeout == 0) {
+    if (gpctx->userproxymode == false || gpctx->term_timeout == 0) {
         /* self termination is disabled */
         return;
     }

--- a/src/gp_socket.c
+++ b/src/gp_socket.c
@@ -219,9 +219,6 @@ int init_activation_socket(struct gssproxy_ctx *gpctx,
         _sock_ctx->fd = fd;
 
         *sock_ctx = _sock_ctx;
-    } else {
-        /* disable self termination as we are not socket activated */
-        gpctx->term_timeout = 0;
     }
 
 done:


### PR DESCRIPTION
The idle timer should definitely be disabled when socket activation is
not being used. Insure that the idle handler does not set up events
when the daemon is not in userproxy mode, and further ensure that
termination is disabled when a regular socket is initialized.

Fixes #56 