### PR TITLE
systemd: add StateDirectory to gssproxy.service

### DIFF
--- a/systemd/gssproxy.service.in
+++ b/systemd/gssproxy.service.in
@@ -5,6 +5,7 @@ After=syslog.target network.target
 Before=rpc-gssd.service
 
 [Service]
+StateDirectory=gssproxy/clients gssproxy/rcache
 Environment=KRB5RCACHEDIR=/var/lib/gssproxy/rcache
 ExecStart=@sbindir@/gssproxy -D
 # These two should be used with traditional UNIX forking daemons


### PR DESCRIPTION
gssproxy won't start if `/var/lib/gssproxy` is missing (_"Failed to create Unix Socket!"_). systemd provides a directive to ensure that all necessary state directories exist so we can use it in this case. The permissions default to 0755, but they could be changed to something more restrictive if necessary.

During `make install` `/var/log/gssproxy` is also created although I'm not sure that it's being used by gssproxy. If it is we can also set `LogsDirectory`.