### PR TITLE
tests: fix userproxytest missed NULL argument pointer

### DIFF
--- a/tests/userproxytest.c
+++ b/tests/userproxytest.c
@@ -17,7 +17,8 @@ char *srv_args[] = {
     "-u", "-i",
     "-d", "--debug-level=1",
     "-s", "./testdir/userproxytest.sock",
-    "--idle-timeout=3"
+    "--idle-timeout=3",
+    NULL
 };
 
 int mock_activation_sockets(void)


### PR DESCRIPTION
Execv syscall needs the argument array of pointers must be terminated by a null pointer, see [manpage](https://www.man7.org/linux/man-pages/man3/exec.3.html), otherwise the garbage data following the
array might break the test.