### PR TITLE
[gssproxy] Try to load the auth_rpcgss module before starting

### DIFF
--- a/systemd/gssproxy.service.in
+++ b/systemd/gssproxy.service.in
@@ -3,6 +3,9 @@ Description=GSSAPI Proxy Daemon
 # GSSPROXY will not be started until syslog is
 After=syslog.target network.target
 Before=rpc-gssd.service
+# auth_rpcgss creates the /proc/net/rpc/use-gss-proxy file
+Wants=modprobe@auth_rpcgss.service
+After=modprobe@auth_rpcgss.service
 
 [Service]
 StateDirectory=gssproxy/clients gssproxy/rcache


### PR DESCRIPTION
If you install gssproxy before nfs-kernel-server (or whatever the equivalent package is named on non-Debian distros), the auth_rpcgss module will typically not be loaded.

This leads to output like this:
  systemd[1]: Starting gssproxy.service - GSSAPI Proxy Daemon...
  gssproxy[1519]: [2023/10/16 20:47:33]: Debug Level changed to 3
  gssproxy[1519]: k5tracer_thread started!
  gssproxy[1519]: [2023/10/16 20:47:33]: Service: nfs-server, Keytab: <some_path>, Enctype: 18
  gssproxy[1521]: [2023/10/16 20:47:33]: Kernel doesn't support GSS-Proxy (can't open /proc/net/rpc/use-gss-proxy: 2 (No such file or directory))
  gssproxy[1521]: [2023/10/16 20:47:33]: Problem with kernel communication!  NFS server will not work
  systemd[1]: Started gssproxy.service - GSSAPI Proxy Daemon.
  gssproxy[1521]: [2023/10/16 20:47:33]: Initialization complete.

And gssproxy won't work properly until the nfs kernel server package(s) have been installed and gssproxy has been restarted (which is kind of difficult to debug) since it won't try opening /proc/net/rpc/use-gss-proxy again.

Signed-off-by: David Härdeman <david@hardeman.nu>