### PR TITLE
Remove syslog.target from service file

### DIFF
--- a/systemd/gssproxy.service.in
+++ b/systemd/gssproxy.service.in
@@ -1,7 +1,6 @@
 [Unit]
 Description=GSSAPI Proxy Daemon
-# GSSPROXY will not be started until syslog is
-After=syslog.target network.target
+After=network.target
 Before=rpc-gssd.service
 
 [Service]


### PR DESCRIPTION
This target hasn't existed for over a decade

https://github.com/systemd/systemd/blob/6aa8d43ade72e24c9426e604f7fc4b7582b9db7c/NEWS#L72-L73