### PR TITLE
Avoid bashism in configure script

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -29,7 +29,7 @@ AC_SUBST([PRERELEASE_VERSION],
 AC_DEFINE([PRERELEASE_VERSION], "PRERELEASE_VERSION_NUMBER",
           [Prerelease version number of package])
 
-AM_CONDITIONAL([GIT_CHECKOUT], [git log -1 &>/dev/null])
+AM_CONDITIONAL([GIT_CHECKOUT], [git log -1 >/dev/null 2>&1])
 
 m4_pattern_allow([AM_SILENT_RULES])
 AM_SILENT_RULES


### PR DESCRIPTION
Currently, the configure script is dumping a log message for the most recent commit into the middle of the output.

&> is non-standard for redirecting stdin and stderr. It is a short-hand copied from csh's >& by zsh and later bash. It is equivalent to >word 2>&1 which will also work in dash (/bin/sh on Debian) or other plain Bourne/POSIX shells.

I would perhaps question whether it might be better to check for the existence of a `.git` directory instead. Or for a git invocation that does less, perhaps run `git rev-parse --git-dir`, though that still needs the redirection. Or drop the autoconf test and handle things within the Makefile. Many projects use other forms such as `git describe --tags --long --abbrev=7` instead. 