### PR TITLE
Fix a segfault in mechglue

### DIFF
--- a/src/client/gpm_indicate_mechs.c
+++ b/src/client/gpm_indicate_mechs.c
@@ -52,6 +52,11 @@ static uint32_t gpm_copy_gss_OID_set(uint32_t *minor_status,
     uint32_t ret_maj;
     uint32_t ret_min;
 
+    if (oldset == GSS_C_NO_OID_SET) {
+	    *newset = GSS_C_NO_OID_SET;
+	    return GSS_S_COMPLETE;
+    }
+
     ret_maj = gss_create_empty_oid_set(&ret_min, &n);
     if (ret_maj) {
         *minor_status = ret_min;

--- a/src/gp_creds.c
+++ b/src/gp_creds.c
@@ -1007,7 +1007,7 @@ uint32_t gp_cred_allowed(uint32_t *min,
     /* if we find an impersonator entry we bail as that is not authorized,
      * *unless* the target is the impersonator itself! If the operation
      * were authorized then gpcall->service->allow_const_deleg would have
-     * caused the ealier check to return GSS_S_COMPLETE already */
+     * caused the earlier check to return GSS_S_COMPLETE already */
     if (impersonator != NULL) {
         ret_maj = check_impersonator_name(&ret_min, target_name, impersonator);
     }

--- a/src/mechglue/gpp_init_sec_context.c
+++ b/src/mechglue/gpp_init_sec_context.c
@@ -178,7 +178,7 @@ OM_uint32 gssi_init_sec_context(OM_uint32 *minor_status,
                 }
                 cred_handle->remote = out_cred;
                 out_cred = NULL;
-                /* failuire is not fatal */
+                /* failure is not fatal */
                 (void)gpp_store_remote_creds(&tmin,
                                              cred_handle->default_creds,
                                              &cred_handle->store,


### PR DESCRIPTION
Protect mechglue against 0-length OID_set coming from the gssproxy