### PR TITLE
Remove the NoNewPrivileges because it breaks the ability to open socket

### DIFF
--- a/systemd/gssproxy.service.in
+++ b/systemd/gssproxy.service.in
@@ -54,7 +54,10 @@ PrivateMounts=yes
 SystemCallFilter=@system-service
 SystemCallErrorNumber=EPERM
 SystemCallArchitectures=native
-NoNewPrivileges=yes
+# NoNewPrivileges=yes
+# NoNewPrivileges: If it is true, it breaks the ability
+#   to open a socket under /var/lib/gssproxy when selinux enabled.
+#   So it is commented out here.
 CapabilityBoundingSet=CAP_DAC_OVERRIDE
 IPAddressDeny=any
 UMask=0177


### PR DESCRIPTION
If NoNewPrivileges is true, it breaks the ability to open a socket under /var/lib/gssproxy when selinux enabled.

The failed messages:
Nov 30 11:37:33 localhost systemd[1]: Starting GSSAPI Proxy Daemon... Nov 30 11:37:34 localhost gssproxy[22445]: gssproxy[22445]: Failed to create Unix Socket! (13:Permission denied) Nov 30 11:37:34 localhost systemd[1]: gssproxy.service: Main process exited, code=exited, status=1/FAILURE Nov 30 11:37:34 localhost systemd[1]: gssproxy.service: Failed with result 'exit-code'. Nov 30 11:37:34 localhost systemd[1]: Failed to start GSSAPI Proxy Daemon.

The audit log:
type=SELINUX_ERR msg=audit(11/30/2024 11:37:34.067:189) : op=security_bounded_transition seresult=denied oldcontext=system_u:system_r:init_t:s0 newcontext=system_u:system_r:gssproxy_t:s0 type=AVC msg=audit(11/30/2024 11:37:34.067:189) : avc:  denied  { nnp_transition } for  pid=22445 comm=(gssproxy) scontext=system_u:system_r:init_t:s0 tcontext=system_u:system_r:gssproxy_t:s0 tclass=process2 permissive=0 ----
type=AVC msg=audit(11/30/2024 11:37:34.080:190) : avc:  denied  { add_name } for  pid=22445 comm=gssproxy name=default.sock scontext=system_u:system_r:init_t:s0 tcontext=system_u:object_r:gssproxy_var_lib_t:s0 tclass=dir permissive=0 ----
type=SERVICE_START msg=audit(11/30/2024 11:37:34.082:191) : pid=1 uid=root auid=unset ses=unset subj=system_u:system_r:init_t:s0 msg='unit=gssproxy comm=systemd exe=/usr/lib/systemd/systemd hostname=? addr=? terminal=? res=failed'