### PR TITLE
Revert "Remove the NoNewPrivileges because it breaks the ability to open socket"

### DIFF
--- a/systemd/gssproxy.service.in
+++ b/systemd/gssproxy.service.in
@@ -54,10 +54,7 @@ PrivateMounts=yes
 SystemCallFilter=@system-service
 SystemCallErrorNumber=EPERM
 SystemCallArchitectures=native
-# NoNewPrivileges=yes
-# NoNewPrivileges: If it is true, it breaks the ability
-#   to open a socket under /var/lib/gssproxy when selinux enabled.
-#   So it is commented out here.
+NoNewPrivileges=yes
 CapabilityBoundingSet=CAP_DAC_OVERRIDE
 IPAddressDeny=any
 UMask=0177


### PR DESCRIPTION
Selinux-policy has allowed init_t nnp domain transition to gssproxy_t in the commit [95d5f5e](https://github.com/fedora-selinux/selinux-policy/commit/95d5f5efd549eaae3e1a811c44b9f0630a902cea). 
Now it is ok to enable NoNewPrivileges for gssproxy.service.