### PR TITLE
Fix gssproxy.conf manpage about comments

### DIFF
--- a/man/gssproxy.conf.5.xml
+++ b/man/gssproxy.conf.5.xml
@@ -27,7 +27,7 @@
         <para>
             GSS-Proxy conf files are classic ini-style configuration files.
             Each option consist of a key = value pair.
-            Any characters behind '#' will be treated as comments and will be ignored.
+            Any line starting with '#' will be treated as comment and will be ignored.
             Boolean parameters accept "1", "true", "yes" and "on" as
             positive values. All other values will be considered as negative
             values.


### PR DESCRIPTION
The manpage was implying it was possible to have comments at the end of configuration lines, while SSSD's ini parsing library used by gssproxy supports full line comments only.