### PR TITLE
Delay krb5 tracing setup in daemon mode

### DIFF
--- a/src/gp_debug.c
+++ b/src/gp_debug.c
@@ -9,7 +9,16 @@
 
 /* global debug switch */
 int gp_debug = 0;
+bool gp_env_trace = false;
 
+/* determine if we can set KRB5_TRACE or the user already set it.
+ * we do not override a user's setting */
+void gp_debug_check_env_(void)
+{
+    if (getenv("KRB5_TRACE")) {
+        gp_env_trace = true;
+    }
+}
 
 void (*gp_debug_setup_k5_trace_fn)(int) = NULL;
 
@@ -27,24 +36,26 @@ void gp_debug_set_krb5_tracing_fn(void (*fn)(int))
      * initial debug level is set via configuration.
      * Make sure to immedaiately call it if debug level is
      * already above 3 */
-    if (gp_debug >= 3 && !getenv("KRB5_TRACE")) {
+    if (gp_debug >= 3 && !gp_env_trace) {
         gp_debug_setup_k5_trace_fn(1);
     }
 }
 
 void gp_debug_toggle(int level)
 {
-    if (level >= 3 && !getenv("KRB5_TRACE")) {
-        if (gp_debug_setup_k5_trace_fn) {
-            gp_debug_setup_k5_trace_fn(1);
-        } else {
-            setenv("KRB5_TRACE", "/dev/stderr", 1);
-        }
-    } else if (level < 3) {
-        if (gp_debug_setup_k5_trace_fn) {
-            gp_debug_setup_k5_trace_fn(0);
-        } else {
-            unsetenv("KRB5_TRACE");
+    if (!gp_env_trace) {
+        if (level >= 3) {
+            if (gp_debug_setup_k5_trace_fn) {
+                gp_debug_setup_k5_trace_fn(1);
+            } else {
+                setenv("KRB5_TRACE", "/dev/stderr", 1);
+            }
+        } else if (level < 3) {
+            if (gp_debug_setup_k5_trace_fn) {
+                gp_debug_setup_k5_trace_fn(0);
+            } else {
+                unsetenv("KRB5_TRACE");
+            }
         }
     }
 

--- a/src/gp_debug.h
+++ b/src/gp_debug.h
@@ -12,6 +12,7 @@
 
 extern int gp_debug;
 
+void gp_debug_check_env_(void);
 void gp_debug_toggle(int);
 void gp_debug_printf(const char *format, ...);
 void gp_debug_time_printf(const char *format, ...);

--- a/src/gssproxy.c
+++ b/src/gssproxy.c
@@ -86,12 +86,16 @@ int main(int argc, const char *argv[])
         goto cleanup;
     }
 
-    /* set tracing function before handling debug level */
-    gp_debug_set_krb5_tracing_fn(&gp_krb5_tracing_setup);
+    gp_debug_check_env_();
 
     if (opt_debug || opt_debug_level > 0) {
         if (opt_debug_level == 0) opt_debug_level = 1;
         gp_debug_toggle(opt_debug_level);
+    }
+
+    /* if we are in interactive mode set up tracing immediately */
+    if (opt_interactive) {
+        gp_debug_set_krb5_tracing_fn(&gp_krb5_tracing_setup);
     }
 
     if (opt_extract_ccache) {
@@ -140,6 +144,12 @@ int main(int argc, const char *argv[])
     }
 
     init_server(gpctx->config->daemonize, opt_userproxy, &wait_fd);
+
+    if (!opt_interactive) {
+        /* set tracing function *after* demonizing, or we kill the
+         * trace reader thread */
+        gp_debug_set_krb5_tracing_fn(&gp_krb5_tracing_setup);
+    }
 
     if (!gpctx->userproxymode) {
         write_pid();


### PR DESCRIPTION
This delays the initialization of the krb5 tracing function until after daemonization when not running interactively. Setting it up earlier caused the trace reader thread to be killed during the fork. It also adds an early check to cache the state of the KRB5_TRACE environment variable, ensuring that gssproxy does not override or unset a user-provided trace configuration.

Fixes #123